### PR TITLE
feat: add -exclude argument to filter public paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Autoswagger automates the process of finding **OpenAPI/Swagger** specifications,
 | `-rate <N>`          | Throttles requests to N requests per second. Default is 30. Use 0 to disable rate limiting.                  |
 | `-b, --brute`        | Enables brute-forcing of parameter values (multiple test combos).                                            |
 | `-json`              | Outputs results in JSON format instead of a Rich table in default mode.                                      |
-
+| `-exclude <...>` | Excludes endpoints whose path contains any of the given substrings.                                              |
 
 ## Help
 
@@ -106,7 +106,7 @@ Autoswagger automates the process of finding **OpenAPI/Swagger** specifications,
                               https://intruder.io
                           Find unauthenticated endpoints
 
-usage: autoswagger.py [-h] [-v] [-risk] [-all] [-product] [-stats] [-rate RATE] [-b] [-json] [urls ...]
+usage: autoswagger.py [-h] [-v] [-risk] [-all] [-product] [-stats] [-rate RATE] [-b] [-json] [-exclude [EXCLUDE ...]] [urls ...] 
 
 Autoswagger: Detect unauthenticated access control issues via Swagger/OpenAPI documentation.
 
@@ -123,6 +123,7 @@ options:
   -rate RATE     Set the rate limit in requests per second (default: 30). Use 0 to disable rate limiting.
   -b, --brute    Enable exhaustive testing of parameter values.
   -json          Output results in JSON format in default mode.
+  -exclude       Exclude endpoints whose path contains any of the given substrings
 
 Example usage:
   python autoswagger.py https://api.example.com -v

--- a/autoswagger.py
+++ b/autoswagger.py
@@ -779,13 +779,16 @@ def test_endpoint(base_url, base_path, path_template, method, parameters, reques
 
 def test_endpoints(base_url, base_path, swagger_spec, verbose=False,
                    include_risk=False, include_all=False, product_mode=False,
-                   rate=30, tried_basepath_fallback=False, brute=False):
+                   rate=30, tried_basepath_fallback=False, brute=False,
+                   exclude_patterns=None):
     """
     Iterates over all paths and methods in the provided swagger_spec.
     Submits tasks to test_endpoint if the method is allowed (GET or others if -risk).
     Returns all aggregated results. Also includes fallback if 80%+ are 404.
     """
     results = []
+    if exclude_patterns is None:
+        exclude_patterns = []
     if not swagger_spec or 'paths' not in swagger_spec:
         if verbose:
             log("Specification does not contain 'paths' key.", level="CRITICAL")
@@ -798,6 +801,8 @@ def test_endpoints(base_url, base_path, swagger_spec, verbose=False,
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_to_endpoint = {}
         for path, methods in swagger_spec['paths'].items():
+            if any(pat in path for pat in exclude_patterns):
+                continue
             if not methods:
                 continue
             for mthd, details in methods.items():
@@ -873,7 +878,8 @@ def test_endpoints(base_url, base_path, swagger_spec, verbose=False,
                 fallback = test_endpoints(
                     base_url, '/', swagger_spec, verbose,
                     include_risk, include_all, product_mode=product_mode,
-                    rate=rate, tried_basepath_fallback=True, brute=brute
+                    rate=rate, tried_basepath_fallback=True, brute=brute,
+                    exclude_patterns=exclude_patterns
                 )
                 return fallback
 
@@ -1125,7 +1131,7 @@ def process_input(urls):
         processed.append(url)
     return processed
 
-def main(urls, verbose, include_risk, include_all, product_mode, stats_flag, rate, brute, json_output):
+def main(urls, verbose, include_risk, include_all, product_mode, stats_flag, rate, brute, json_output, exclude_patterns):
     """
     Main function controlling flow:
     1. Tracks start time
@@ -1185,7 +1191,8 @@ def main(urls, verbose, include_risk, include_all, product_mode, stats_flag, rat
                 rslts = test_endpoints(
                     base_url, base_path, swagger_spec,
                     verbose, include_risk, include_all,
-                    product_mode=product_mode, rate=rate, brute=brute
+                    product_mode=product_mode, rate=rate, brute=brute,
+                    exclude_patterns=exclude_patterns
                 )
                 del swagger_spec
                 with results_lock:
@@ -1222,7 +1229,8 @@ def main(urls, verbose, include_risk, include_all, product_mode, stats_flag, rat
             rslts = test_endpoints(
                 base_url, base_path, swagger_spec,
                 verbose, include_risk, include_all,
-                product_mode=product_mode, rate=rate, brute=brute
+                product_mode=product_mode, rate=rate, brute=brute,
+                exclude_patterns=exclude_patterns
             )
             del swagger_spec
             with results_lock:
@@ -1259,7 +1267,8 @@ def main(urls, verbose, include_risk, include_all, product_mode, stats_flag, rat
                 rslts2 = test_endpoints(
                     base_url, base_path, sws,
                     verbose, include_risk, include_all,
-                    product_mode=product_mode, rate=rate, brute=brute
+                    product_mode=product_mode, rate=rate, brute=brute,
+                    exclude_patterns=exclude_patterns
                 )
                 del sws
                 with results_lock:
@@ -1464,6 +1473,7 @@ if __name__ == "__main__":
     parser.add_argument("-rate", type=int, default=30, help="Set the rate limit in requests per second (default: 30). Use 0 to disable rate limiting.")
     parser.add_argument("-b", "--brute", action="store_true", help="Enable exhaustive testing of parameter values.")
     parser.add_argument("-json", action="store_true", help="Output results in JSON format in default mode.")
+    parser.add_argument("-exclude", nargs="*", help="Exclude endpoints whose path contains any of the given substrings")
 
     args = parser.parse_args()
 
@@ -1485,6 +1495,7 @@ if __name__ == "__main__":
     rate = args.rate
     brute = args.brute
     json_output = args.json
+    exclude_patterns = args.exclude or []
 
     # Set up file logging if verbose is enabled
     if verbose:
@@ -1498,4 +1509,4 @@ if __name__ == "__main__":
         logger.addHandler(file_handler)
         logger.propagate = False
 
-    main(urls, verbose, include_risk, include_all, product_mode, stats_flag, rate, brute, json_output)
+    main(urls, verbose, include_risk, include_all, product_mode, stats_flag, rate, brute, json_output, exclude_patterns)


### PR DESCRIPTION
## Summary

- Many apps expose public surfaces (/public, /static ). Including these in results yields misleading “200 OK” findings that don’t indicate broken auth, so an explicit exclude lets users keep the signal high and focus on potentially misconfigured unauthenticated endpoints.

## Changes

- Add CLI flag -exclude [EXCLUDE ...] to accept multiple substrings used to filter paths in enumeration.
- Apply filtering across all discovery phases by passing exclude_patterns into test_endpoints method.
- Skip paths when any exclude substring matches.
- Document the flag and updated usage in the README file.